### PR TITLE
[PIZ-1] - Unable to create order 

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,10 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+@size.route('/', methods=GET)
+def get_sizes():
+    sizes, error = SizeController.get_all()
+    response = sizes if not error else {'error': error}
+    status_code = 200 if sizes else 404 if not error else 400
+    return jsonify(response), status_code

--- a/app/test/services/test_sizes.py
+++ b/app/test/services/test_sizes.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+def test_get_sizes_service(client, create_sizes, size_uri):
+    response = client.get(size_uri)
+    pytest.assume(response.status.startswith('200'))
+    returned_sizes = {size['_id']: size for size in response.json}
+    for size in create_sizes:
+        pytest.assume(size['_id'] in returned_sizes)


### PR DESCRIPTION
**🤔 Why?**
We need to be able to make a complete orden. The pizza planet app should allow users to select a pizza size and ingredients so that the order can be successfully created.
**🛠 What I changed:**

- I added the method to get all pizza sizes
- I implement it´s test

**🗃️ Trello Ticket:**
[PIZ-1](https://trello.com/c/iAdVroEB/1-piz-1-unable-to-create-order-bug)

**🚦 Functional Testing Results:**

![image](https://github.com/user-attachments/assets/5b9b4263-bd89-432d-b348-799a25df41bf)

**📷 Screenshots**

![image](https://github.com/user-attachments/assets/a5f5eb74-25e9-4de3-873c-fa4c57ec1095)
![image](https://github.com/user-attachments/assets/7b779389-d6e0-4c30-8b44-17daa523a486)

